### PR TITLE
Use EVALSHA, allow redis authentication and reuse connections

### DIFF
--- a/redsync/mutex_test.go
+++ b/redsync/mutex_test.go
@@ -30,6 +30,7 @@ func TestMain(m *testing.M) {
 		if err != nil {
 			panic(err)
 		}
+		defer server.Kill()
 		servers[i] = server
 	}
 	result := m.Run()

--- a/redsync/mutex_test.go
+++ b/redsync/mutex_test.go
@@ -3,10 +3,13 @@ package redsync_test
 import (
 	"math/rand"
 	"net"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/hjr265/redsync.go/redsync"
+	"github.com/stvp/tempredis"
 )
 
 var addrs = []net.Addr{
@@ -14,6 +17,26 @@ var addrs = []net.Addr{
 	&net.TCPAddr{Port: 63791},
 	&net.TCPAddr{Port: 63792},
 	&net.TCPAddr{Port: 63793},
+}
+
+var servers []*tempredis.Server
+
+func TestMain(m *testing.M) {
+	servers = make([]*tempredis.Server, len(addrs))
+	for i, addr := range addrs {
+		parts := strings.Split(addr.String(), ":")
+		port := parts[1]
+		server, err := tempredis.Start(tempredis.Config{"port": port})
+		if err != nil {
+			panic(err)
+		}
+		servers[i] = server
+	}
+	result := m.Run()
+	for _, server := range servers {
+		server.Kill()
+	}
+	os.Exit(result)
 }
 
 func TestMutex(t *testing.T) {

--- a/redsync/mutex_test.go
+++ b/redsync/mutex_test.go
@@ -32,7 +32,7 @@ func TestMutex(t *testing.T) {
 			for j := 0; j < 32; j++ {
 				err := m.Lock()
 				if err == redsync.ErrFailed {
-					f += 1
+					f++
 					if f > 2 {
 						chErr <- err
 						return


### PR DESCRIPTION
This PR includes:
 - [x] Refactoring to make code pass glint
 - [x] Change library from radix to redigo, which includes using EVALSHA (fixes #2)
 - [x] Use `tempredis` to automatically start redis servers for testing
 - [x] Add `NewMutexWithPool` so redigo's Pool of hosts can be used, allowing reusing existing redis connections.
 - [x] Allow redis authentication using redis.Pool Dial. See [redis.Pool example](http://godoc.org/github.com/garyburd/redigo/redis#Pool)

@hjr265 let me know what you think.