### PR TITLE
made Pool an interface (pool)

### DIFF
--- a/redsync/mutex.go
+++ b/redsync/mutex.go
@@ -36,11 +36,12 @@ type Locker interface {
 	Unlock()
 }
 
-type Pool interface {
+// pool is a connection pool
+type pool interface {
 	Get() redis.Conn
 }
 
-var _ = Pool(&redis.Pool{})
+var _ = pool(&redis.Pool{})
 
 // A Mutex is a mutual exclusion lock.
 //
@@ -59,7 +60,7 @@ type Mutex struct {
 	value string
 	until time.Time
 
-	nodes []Pool
+	nodes []pool
 	nodem sync.Mutex
 }
 
@@ -71,7 +72,7 @@ func NewMutex(name string, addrs []net.Addr) (*Mutex, error) {
 		panic("redsync: addrs is empty")
 	}
 
-	nodes := make([]Pool, len(addrs))
+	nodes := make([]pool, len(addrs))
 	for i, addr := range addrs {
 		dialTo := addr
 		node := &redis.Pool{
@@ -81,14 +82,14 @@ func NewMutex(name string, addrs []net.Addr) (*Mutex, error) {
 				return redis.Dial("tcp", dialTo.String())
 			},
 		}
-		nodes[i] = Pool(node)
+		nodes[i] = pool(node)
 	}
 
 	return NewMutexWithPool(name, nodes)
 }
 
 // NewMutexWithPool returns a new Mutex on a named resource connected to the Redis instances at given redis Pools.
-func NewMutexWithPool(name string, nodes []Pool) (*Mutex, error) {
+func NewMutexWithPool(name string, nodes []pool) (*Mutex, error) {
 	if len(nodes) == 0 {
 		panic("redsync: nodes is empty")
 	}

--- a/redsync/mutex.go
+++ b/redsync/mutex.go
@@ -85,19 +85,38 @@ func NewMutex(name string, addrs []net.Addr) (*Mutex, error) {
 		nodes[i] = Pool(node)
 	}
 
-	return NewMutexWithPool(name, nodes)
+	return NewMutexWithGenericPool(name, nodes)
 }
 
 // NewMutexWithPool returns a new Mutex on a named resource connected to the Redis instances at given redis Pools.
-func NewMutexWithPool(name string, nodes []Pool) (*Mutex, error) {
+func NewMutexWithPool(name string, nodes []*redis.Pool) (*Mutex, error) {
 	if len(nodes) == 0 {
 		panic("redsync: nodes is empty")
 	}
 
+	genericNodes := make([]Pool, len(nodes))
+	for i, node := range nodes {
+		genericNodes[i] = Pool(node)
+	}
+
 	return &Mutex{
 		Name:   name,
-		Quorum: len(nodes)/2 + 1,
-		nodes:  nodes,
+		Quorum: len(genericNodes)/2 + 1,
+		nodes:  genericNodes,
+	}, nil
+}
+
+// NewMutexWithGenericPool returns a new Mutex on a named resource connected to the Redis instances at given generic Pools.
+// different from NewMutexWithPool to maintain backwards compatibility
+func NewMutexWithGenericPool(name string, genericNodes []Pool) (*Mutex, error) {
+	if len(genericNodes) == 0 {
+		panic("redsync: genericNodes is empty")
+	}
+
+	return &Mutex{
+		Name:   name,
+		Quorum: len(genericNodes)/2 + 1,
+		nodes:  genericNodes,
 	}, nil
 }
 


### PR DESCRIPTION
As it stands having Mutex.nodes as a  struct array ([]*redis.Pool) limits the use of this library as it can't be adapted to our more specific pools.