### PR TITLE
Skip delay on last try to lock

### DIFF
--- a/redsync/mutex.go
+++ b/redsync/mutex.go
@@ -231,6 +231,11 @@ func (m *Mutex) Lock() error {
 			}
 		}
 
+		// Have no delay on the last try so we can return ErrFailed sooner.
+		if i == retries-1 {
+			continue
+		}
+
 		delay := m.Delay
 		if delay == 0 {
 			delay = DefaultDelay


### PR DESCRIPTION
We can return to the caller sooner in this case.
